### PR TITLE
gitkraken 3.1.2

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@ pkgdesc="Git client with efficiency, elegance and reliability at the core"
 arch=('x86_64')
 url="https://www.gitkraken.com/"
 license=('custom: https://www.gitkraken.com/eula')
-depends=('curl-kcp' 'libcurl-gnutls' 'gconf' 'gtk2' 'nss' 'libxtst' 'libnotify' 'alsa-lib' 'libgnome-keyring')
+depends=('curl-kcp' 'gconf' 'gtk2' 'nss' 'libxtst' 'libnotify' 'alsa-lib' 'libgnome-keyring')
 source=("https://release.gitkraken.com/linux/v${pkgver}.tar.gz"
         "${pkgname}.desktop"
         "${pkgname}.svg"
@@ -13,7 +13,7 @@ source=("https://release.gitkraken.com/linux/v${pkgver}.tar.gz"
 md5sums=('b3fd4e4a4278db2d2f4eac5b86be6758'
          'e70ed2fa89e0929c02262f9300f0f1b2'
          '952efc24804093bec7a95efe02d18c48'
-         'bc26295f9c6d5c2e2a4d662a1924a616')
+         '10af5f5f6e5253f3b742982ebde6c1ae')
 
 package() {
     install -dm755 ${pkgdir}/opt/${pkgname} \

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,16 +1,16 @@
 pkgname=gitkraken
-pkgver=3.0.0
+pkgver=3.1.2
 pkgrel=1
 pkgdesc="Git client with efficiency, elegance and reliability at the core"
 arch=('x86_64')
 url="https://www.gitkraken.com/"
 license=('custom: https://www.gitkraken.com/eula')
-depends=('curl-kcp' 'gconf' 'gtk2' 'nss' 'libxtst' 'libnotify' 'alsa-lib' 'libgnome-keyring')
+depends=('curl-kcp' 'libcurl-gnutls' 'gconf' 'gtk2' 'nss' 'libxtst' 'libnotify' 'alsa-lib' 'libgnome-keyring')
 source=("https://release.gitkraken.com/linux/v${pkgver}.tar.gz"
         "${pkgname}.desktop"
         "${pkgname}.svg"
         "${pkgname}.sh")
-md5sums=('be99869e7a9620b66a8b135bd86d2ff4'
+md5sums=('b3fd4e4a4278db2d2f4eac5b86be6758'
          'e70ed2fa89e0929c02262f9300f0f1b2'
          '952efc24804093bec7a95efe02d18c48'
          'bc26295f9c6d5c2e2a4d662a1924a616')

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ Git client with efficiency, elegance and reliability at the core
 kcp -di curl-kcp
 ```
 
-### Required manual build:
-The needed dependency `libcurl-gnutls` is currently not build for KaOS, but the PKGBUILD can be found [in this repository](https://github.com/wrajaka/kcp-libcurl-gnutls/blob/master/PKGBUILD) and has [to be build](https://kaosx.us/docs/package/#building-a-package) manually and installed prior as a dependency with `--asdeps`.
-
 ### Install:
 ```
 kcp -i gitkraken

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Git client with efficiency, elegance and reliability at the core
 kcp -di curl-kcp
 ```
 
+### Required manual build:
+The needed dependency `libcurl-gnutls` is currently not build for KaOS, but the PKGBUILD can be found [in this repository](https://github.com/wrajaka/kcp-libcurl-gnutls/blob/master/PKGBUILD) and has [to be build](https://kaosx.us/docs/package/#building-a-package) manually and installed prior as a dependency with `--asdeps`.
+
 ### Install:
 ```
 kcp -i gitkraken

--- a/gitkraken.sh
+++ b/gitkraken.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # -*- ENCODING: UTF-8 -*-
 
-LD_PRELOAD='/opt/curl/lib/libcurl.so' /opt/gitkraken/gitkraken
+LD_PRELOAD='/usr/lib/libcurl-gnutls.so.4' /opt/gitkraken/gitkraken


### PR DESCRIPTION
This release has dependency to [libcurl-gnutls](https://github.com/wrajaka/kcp-libcurl-gnutls) that need to be manually build. This information is added in README file.